### PR TITLE
🐛 Fix ESLint errors in BottomActions.tsx

### DIFF
--- a/src/app/[variants]/(main)/_layout/Desktop/SideBar/BottomActions.tsx
+++ b/src/app/[variants]/(main)/_layout/Desktop/SideBar/BottomActions.tsx
@@ -1,28 +1,8 @@
-import { ActionIcon, ActionIconProps } from '@lobehub/ui';
-import { Book, Github } from 'lucide-react';
-import Link from 'next/link';
 import { memo } from 'react';
-import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
 
-import { DOCUMENTS_REFER_URL, GITHUB } from '@/const/url';
-import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
-
-const ICON_SIZE: ActionIconProps['size'] = {
-  blockSize: 36,
-  size: 20,
-  strokeWidth: 1.5,
-};
-
 const BottomActions = memo(() => {
-  const { t } = useTranslation('common');
-  const { hideGitHub, hideDocs } = useServerConfigStore(featureFlagsSelectors);
-
-  return (
-    <Flexbox gap={8}>
-      {/* GitHub and documentation links removed as requested */}
-    </Flexbox>
-  );
+  return <Flexbox gap={8}>{/* GitHub and documentation links removed as requested */}</Flexbox>;
 });
 
 export default BottomActions;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🐛 fix

#### 🔀 变更说明 | Description of Change

Fixed ESLint errors that were causing the build to fail in the Vercel deployment. The errors were in `src/app/[variants]/(main)/_layout/Desktop/SideBar/BottomActions.tsx` where several variables and imports were declared but never used.

**Changes made:**
- Removed unused variables: `ICON_SIZE`, `t`, `hideGitHub`, `hideDocs`
- Removed unused imports:
  - `ActionIcon`, `ActionIconProps` from `@lobehub/ui`
  - `Book`, `Github` from `lucide-react`
  - `Link` from `next/link`
  - `useTranslation` from `react-i18next`
  - `DOCUMENTS_REFER_URL`, `GITHUB` from `@/const/url`
  - `featureFlagsSelectors`, `useServerConfigStore` from `@/store/serverConfig`
- Kept only necessary imports: `memo` from `react` and `Flexbox` from `react-layout-kit`

**Build Status:**
- ✅ ESLint errors resolved
- ✅ Linting process passes successfully
- ✅ Component structure remains intact (empty Flexbox as intended for branding removal)

#### 📝 补充信息 | Additional Information

This fix resolves the build failure that was occurring during the Vercel deployment process. The original error log showed:

```
/vercel/path0/src/app/[variants]/(main)/_layout/Desktop/SideBar/BottomActions.tsx
   8:7   error    'ICON_SIZE' is assigned a value but never used
  15:11  error    't' is assigned a value but never used
  16:11  error    'hideGitHub' is assigned a value but never used
  16:23  error    'hideDocs' is assigned a value but never used
```

These unused variables were likely left over from when the GitHub and documentation links were removed as part of the branding changes. The component now has a clean, minimal structure that maintains the intended functionality while passing all linting checks.

@hnmdevs can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d057ae6370f04afeb3a0dc7290be114a)